### PR TITLE
Add Wikidata IDs to title and author ref attributes in level1 XML files

### DIFF
--- a/level1/POR0001_JulDin_Morgadinha.xml
+++ b/level1/POR0001_JulDin_Morgadinha.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>A Morgadinha dos Canaviais : Edição para o ELTeC</title>
+<title ref="wikidata:Q4658368">A Morgadinha dos Canaviais : Edição para o ELTeC</title>
 <title level="s">Crónica da aldeia</title>
-<author ref="viaf:36941922">Dinis, Júlio [Joaquim Guilherme Gomes Coelho] (1839-1871)</author>
+<author ref="viaf:36941922 wikidata:Q980339">Dinis, Júlio [Joaquim Guilherme Gomes Coelho] (1839-1871)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Rita Farinha</name>

--- a/level1/POR0002_AnaCO_Sacrificada.xml
+++ b/level1/POR0002_AnaCO_Sacrificada.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>Sacrificada: Edição para o ELTeC</title>
-        <author ref="viaf:68982250">Castro Osório, Ana de (1872-1935)</author>
+        <title ref="wikidata:Q111096273">Sacrificada: Edição para o ELTeC</title>
+        <author ref="viaf:68982250 wikidata:Q2817249">Castro Osório, Ana de (1872-1935)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Pedro Saborano</name>

--- a/level1/POR0003_AleHer_Cister.xml
+++ b/level1/POR0003_AleHer_Cister.xml
@@ -7,7 +7,7 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>O Monge de Cister: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096249">O Monge de Cister: Edição para o ELTeC</title>
 <title level="s">ou: A época de D. João I</title>
 <author>Herculano, Alexandre (1810-1877)</author>
 <respStmt>

--- a/level1/POR0004_AlmGar_Viagens.xml
+++ b/level1/POR0004_AlmGar_Viagens.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Viagens na minha terra: Edição para o ELTeC</title>
-<author ref="viaf:12303244">Almeida Garrett, João Baptista da Silva Leitão de (1799-1854)</author>
+<title ref="wikidata:Q9093172">Viagens na minha terra: Edição para o ELTeC</title>
+<author ref="viaf:12303244 wikidata:Q316806">Almeida Garrett, João Baptista da Silva Leitão de (1799-1854)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Rita Farinha</name>

--- a/level1/POR0005_EcaQue_Maias.xml
+++ b/level1/POR0005_EcaQue_Maias.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Os Maias: Edição para o ELTeC</title>
+<title ref="wikidata:Q3057582">Os Maias: Edição para o ELTeC</title>
 <title level="s">Episódios da Vida Romântica</title>
-<author ref="viaf:88719234">Eça de Queirós, José Maria de (1845-1900)</author>
+<author ref="viaf:88719234 wikidata:Q316327">Eça de Queirós, José Maria de (1845-1900)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Rita Farinha</name>

--- a/level1/POR0006_MMSAV_Lourenco.xml
+++ b/level1/POR0006_MMSAV_Lourenco.xml
@@ -7,7 +7,7 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>O Cura de São Lourenço: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096236">O Cura de São Lourenço: Edição para o ELTeC</title>
 <author>Vasconcelos, Maria do Monte de Santana e (1809-1884)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>

--- a/level1/POR0007_JulDin_Inglesa.xml
+++ b/level1/POR0007_JulDin_Inglesa.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Uma família ingleza: Edição para o ELTeC</title>
+<title ref="wikidata:Q10387423">Uma família ingleza: Edição para o ELTeC</title>
 <title level="s">Scenas da vida do Porto</title>
-<author ref="viaf:36941922">Dinis, Júlio [Joaquim Guilherme Gomes Coelho] (1839-1871)</author>
+<author ref="viaf:36941922 wikidata:Q980339">Dinis, Júlio [Joaquim Guilherme Gomes Coelho] (1839-1871)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Biblioteca Nacional Digital (http://bnd.bn.pt)</name>

--- a/level1/POR0008_EcaQue_Ramires.xml
+++ b/level1/POR0008_EcaQue_Ramires.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>A ilustre casa de Ramires: Edição para o ELTeC</title>
-<author ref="viaf:88719234">Eça de Queirós, José Maria de (1845-1900)</author>
+<title ref="wikidata:Q15634456">A ilustre casa de Ramires: Edição para o ELTeC</title>
+<author ref="viaf:88719234 wikidata:Q316327">Eça de Queirós, José Maria de (1845-1900)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Rita Farinha</name>

--- a/level1/POR0009_EcaQue_Amaro.xml
+++ b/level1/POR0009_EcaQue_Amaro.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>O Crime do Padre Amaro: Edição para o ELTeC</title>
+<title ref="wikidata:Q3282044">O Crime do Padre Amaro: Edição para o ELTeC</title>
 <title level="s">Cenas da Vida Devota</title>
-<author ref="viaf:88719234">Eça de Queirós, José Maria de (1845-1900)</author>
+<author ref="viaf:88719234 wikidata:Q316327">Eça de Queirós, José Maria de (1845-1900)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Rita Farinha</name>

--- a/level1/POR0010_CamCB_Perdicao.xml
+++ b/level1/POR0010_CamCB_Perdicao.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Amor de Perdição: Edição para o ELTeC</title>
+<title ref="wikidata:Q3614519">Amor de Perdição: Edição para o ELTeC</title>
 <title level="s">Memórias duma família</title>
-<author ref="viaf:7399630">Castelo Branco, Camilo (1825-1890)</author>
+<author ref="viaf:7399630 wikidata:Q365423">Castelo Branco, Camilo (1825-1890)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Rita Farinha</name>

--- a/level1/POR0011_CamCB_Mulheres.xml
+++ b/level1/POR0011_CamCB_Mulheres.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>O que fazem mulheres: Edição para o ELTeC</title>
+        <title ref="wikidata:Q89458409">O que fazem mulheres: Edição para o ELTeC</title>
 <title level="s">Romance filosófico</title>
-        <author ref="viaf:7399630">Castelo Branco, Camilo (1825-1890)</author>
+        <author ref="viaf:7399630 wikidata:Q365423">Castelo Branco, Camilo (1825-1890)</author>
         <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Pedro Saborano</name>

--- a/level1/POR0012_CamCB_Misterios.xml
+++ b/level1/POR0012_CamCB_Misterios.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>Mistérios de Lisboa: Edição para o ELTeC</title>
-        <author ref="viaf:7399630">Castelo Branco, Camilo (1825-1890)</author>
+        <title ref="wikidata:Q10331148">Mistérios de Lisboa: Edição para o ELTeC</title>
+        <author ref="viaf:7399630 wikidata:Q365423">Castelo Branco, Camilo (1825-1890)</author>
         <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Luso-livros</name>

--- a/level1/POR0013_RauBra_Pobres.xml
+++ b/level1/POR0013_RauBra_Pobres.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Os pobres: Edição para o ELTeC</title>
-<author ref="viaf:17219789">Brandão, Raul (1867-1930)</author>
+<title ref="wikidata:Q111096267">Os pobres: Edição para o ELTeC</title>
+<author ref="viaf:17219789 wikidata:Q2035991">Brandão, Raul (1867-1930)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Manuela Alves</name>

--- a/level1/POR0014_FauFon_Mindelo.xml
+++ b/level1/POR0014_FauFon_Mindelo.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>Os Bravos do Mindelo: Edição para o ELTeC</title>
-        <author ref="viaf:86910399">Fonseca, Faustino da (1871-1918)</author>
+        <title ref="wikidata:Q111096257">Os Bravos do Mindelo: Edição para o ELTeC</title>
+        <author ref="viaf:86910399 wikidata:Q10280314">Fonseca, Faustino da (1871-1918)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Ricardo F. Diogo</name>

--- a/level1/POR0015_JulDin_Fidalgos.xml
+++ b/level1/POR0015_JulDin_Fidalgos.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Os Fidalgos da Casa Mourisca: Edição para o ELTeC</title>
+<title ref="wikidata:Q10341960">Os Fidalgos da Casa Mourisca: Edição para o ELTeC</title>
 <title level="s">Crónica da Aldeia</title>
-<author ref="viaf:36941922">Dinis, Júlio [Joaquim Guilherme Gomes Coelho] (1839-1871)</author>
+<author ref="viaf:36941922 wikidata:Q980339">Dinis, Júlio [Joaquim Guilherme Gomes Coelho] (1839-1871)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Biblioteca Nacional Digital (http://bnd.bn.pt)</name>

--- a/level1/POR0016_LARSil_Fantasmas.xml
+++ b/level1/POR0016_LARSil_Fantasmas.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>A casa dos fantasmas: Edição para o ELTeC</title>
+        <title ref="wikidata:Q111096172">A casa dos fantasmas: Edição para o ELTeC</title>
 	<title level="s"> Episódio do tempo dos franceses</title>
-        <author ref="viaf:65062129">Silva, Luís Augusto Rebelo da (1822-1871)</author>
+        <author ref="viaf:65062129 wikidata:Q10321293">Silva, Luís Augusto Rebelo da (1822-1871)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Ricardo F. Diogo</name>

--- a/level1/POR0017_MJPCha_Meianoite.xml
+++ b/level1/POR0017_MJPCha_Meianoite.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>A Lenda da Meia-Noite: Edição para o ELTeC</title>
-        <author ref="viaf:12303053">Pinheiro Chagas, Manuel Joaquim (1842-1895)</author>
+        <title ref="wikidata:Q111096185">A Lenda da Meia-Noite: Edição para o ELTeC</title>
+        <author ref="viaf:12303053 wikidata:Q1891579">Pinheiro Chagas, Manuel Joaquim (1842-1895)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Ricardo F. Diogo</name>

--- a/level1/POR0018_AntAlb_Bacalhoa.xml
+++ b/level1/POR0018_AntAlb_Bacalhoa.xml
@@ -7,7 +7,7 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>O Marquês da Bacalhoa: Edição para o ELTeC</title>
+        <title ref="wikidata:Q111096242">O Marquês da Bacalhoa: Edição para o ELTeC</title>
         <author>Albuquerque, António de (1866-1923)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>

--- a/level1/POR0019_MarSC_Lucio.xml
+++ b/level1/POR0019_MarSC_Lucio.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>A Confissão de Lúcio: Edição para o ELTeC</title>
+        <title ref="wikidata:Q16142111">A Confissão de Lúcio: Edição para o ELTeC</title>
 <title level="s">novela vulgar lisboeta</title>
-        <author ref="viaf:66476723">Sá-Carneiro, Mário de (1890-1916)</author>
+        <author ref="viaf:66476723 wikidata:Q466945">Sá-Carneiro, Mário de (1890-1916)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Luso-Livros</name>

--- a/level1/POR0020_AbeBot_Crioulo.xml
+++ b/level1/POR0020_AbeBot_Crioulo.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-<title>Amor crioulo: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096204">Amor crioulo: Edição para o ELTeC</title>
 <title level="s">Vida argentina</title>
-      <author ref="viaf:37048086">Botelho, Abel (1856-1917)</author>
+      <author ref="viaf:37048086 wikidata:Q318390">Botelho, Abel (1856-1917)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Rita Farinha</name>

--- a/level1/POR0021_ConFic_Eleicao.xml
+++ b/level1/POR0021_ConFic_Eleicao.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
    <titleStmt>
-    <title>Uma Eleição Perdida: Edição para o ELTeC</title>
-    <author ref="viaf:51706969">Ficalho, Francisco Manuel de Melo Breyner, Conde de (1837-1903)</author>
+    <title ref="wikidata:Q111096278">Uma Eleição Perdida: Edição para o ELTeC</title>
+    <author ref="viaf:51706969 wikidata:Q10284967">Ficalho, Francisco Manuel de Melo Breyner, Conde de (1837-1903)</author>
     <respStmt>
       <resp>Criação do HTML original</resp>
      <name>Vanda Morgado</name>

--- a/level1/POR0022_AlbPim_Cintra.xml
+++ b/level1/POR0022_AlbPim_Cintra.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>Noites de Cintra: Edição para o ELTeC</title>
-        <author ref="viaf:64047987">Pimentel, Alberto (1849-1925)</author>
+        <title ref="wikidata:Q111096225">Noites de Cintra: Edição para o ELTeC</title>
+        <author ref="viaf:64047987 wikidata:Q16487084">Pimentel, Alberto (1849-1925)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Pedro Saborano</name>

--- a/level1/POR0023_AleHer_Eurico.xml
+++ b/level1/POR0023_AleHer_Eurico.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title> Eurico, o Presbítero: Edição para o ELTeC</title>
+<title ref="wikidata:Q10278261"> Eurico, o Presbítero: Edição para o ELTeC</title>
 <title level="s">ou: A época de D. João I</title>
-<author ref="viaf:2464795">Herculano, Alexandre (1810-1877)</author>
+<author ref="viaf:2464795 wikidata:Q520688">Herculano, Alexandre (1810-1877)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Rita Farinha</name>

--- a/level1/POR0024_AlfCam_Cabinda.xml
+++ b/level1/POR0024_AlfCam_Cabinda.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>A filha do Cabinda: Edição para o ELTeC</title>
-        <author ref="viaf:306447935">Campos, Alfredo Luís de (1856-1931)</author>
+        <title ref="wikidata:Q111096179">A filha do Cabinda: Edição para o ELTeC</title>
+        <author ref="viaf:306447935 wikidata:Q9603051">Campos, Alfredo Luís de (1856-1931)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Pedro Saborano</name>

--- a/level1/POR0025_ManMRod_Rosa.xml
+++ b/level1/POR0025_ManMRod_Rosa.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>A Rosa do Adro: Edição para o ELTeC</title>
-        <author ref="viaf:48368103">Rodrigues, Manuel Maria (1847-1899)</author>
+        <title ref="wikidata:Q111096191">A Rosa do Adro: Edição para o ELTeC</title>
+        <author ref="viaf:48368103 wikidata:Q109586139">Rodrigues, Manuel Maria (1847-1899)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Luso-Livros</name>

--- a/level1/POR0026_TeiQue_Salustio.xml
+++ b/level1/POR0026_TeiQue_Salustio.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>O Salústio Nogueira: Edição para o ELTeC</title>
-        <author ref="viaf:51244569">Teixeira de Queirós, Francisco (1848-1919)</author>
+        <title ref="wikidata:Q111096252">O Salústio Nogueira: Edição para o ELTeC</title>
+        <author ref="viaf:51244569 wikidata:Q10379131">Teixeira de Queirós, Francisco (1848-1919)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Adeliana Silva</name>

--- a/level1/POR0027_MJTM_MariaDaFonte.xml
+++ b/level1/POR0027_MJTM_MariaDaFonte.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>Um conto portuguez: Edição para o ELTeC</title>
+        <title ref="wikidata:Q111096276">Um conto portuguez: Edição para o ELTeC</title>
         <title level="s">episódio da guerra civil: a Maria da Fonte</title>
-        <author ref="viaf:99421824">Mascarenhas, Miguel J. T. (?-?)</author>
+        <author ref="viaf:99421824 wikidata:Q111081937">Mascarenhas, Miguel J. T. (?-?)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Manuela Alves</name>

--- a/level1/POR0028_SMagLim_Viscondessa.xml
+++ b/level1/POR0028_SMagLim_Viscondessa.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>A senhora viscondessa: Edição para o ELTeC</title>
-        <author ref="viaf:56893154">Lima, Sebastião de Magalhães (1850-1928)</author>
+        <title ref="wikidata:Q111096198">A senhora viscondessa: Edição para o ELTeC</title>
+        <author ref="viaf:56893154 wikidata:Q3476927">Lima, Sebastião de Magalhães (1850-1928)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Pedro Saborano</name>

--- a/level1/POR0029_DiodMac_Cristao.xml
+++ b/level1/POR0029_DiodMac_Cristao.xml
@@ -7,7 +7,7 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>O cristão novo: Edição para o ELTeC</title>
+        <title ref="wikidata:Q111096235">O cristão novo: Edição para o ELTeC</title>
         <title level="s">romance histórico do século XVI</title>
         <author ref="viaf:99906308">Macedo, Diogo de (1844-1938)</author>
         <respStmt>

--- a/level1/POR0030_FelCas_Chave.xml
+++ b/level1/POR0030_FelCas_Chave.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>A chave do enigma: Edição para o ELTeC</title>
-        <author ref="viaf:135007">Castilho, António Feliciano de (1800-1875)</author>
+        <title ref="wikidata:Q111096173">A chave do enigma: Edição para o ELTeC</title>
+        <author ref="viaf:135007 wikidata:Q2624029">Castilho, António Feliciano de (1800-1875)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Pedro Saborano</name>

--- a/level1/POR0031_ZNGB_Covilha.xml
+++ b/level1/POR0031_ZNGB_Covilha.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>Pero da Covilhã: Edição para o ELTeC</title>
+        <title ref="wikidata:Q111096271">Pero da Covilhã: Edição para o ELTeC</title>
 <title level="s">Episódio Romântico do Século XV</title>
-        <author ref="viaf:99344619">Brandão, Zeferino Norberto Gonçalves (1842-1910)</author>
+        <author ref="viaf:99344619 wikidata:Q10394987">Brandão, Zeferino Norberto Gonçalves (1842-1910)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Pedro Saborano</name>

--- a/level1/POR0032_JayMLim_Transviado.xml
+++ b/level1/POR0032_JayMLim_Transviado.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>Transviado: Edição para o ELTeC</title>
-        <author ref="viaf:6967932">Lima, Jaime de Magalhães (1859-1936)</author>
+        <title ref="wikidata:Q111096275">Transviado: Edição para o ELTeC</title>
+        <author ref="viaf:6967932 wikidata:Q385138">Lima, Jaime de Magalhães (1859-1936)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Pedro Saborano</name>

--- a/level1/POR0033_ACCSA_Anselmo.xml
+++ b/level1/POR0033_ACCSA_Anselmo.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>Os filhos do padre Anselmo: Edição para o ELTeC</title>
-        <author ref="viaf:99372166">Albergaria, António da Costa Couto Sá de (1850-1921)</author>
+        <title ref="wikidata:Q111096261">Os filhos do padre Anselmo: Edição para o ELTeC</title>
+        <author ref="viaf:99372166 wikidata:Q9619400">Albergaria, António da Costa Couto Sá de (1850-1921)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Ricardo F. Diogo</name>

--- a/level1/POR0034_TomMel_Luiz.xml
+++ b/level1/POR0034_TomMel_Luiz.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>O Conde de S. Luís: Edição para o ELTeC</title>
-        <author ref="viaf:99963991">Melo, Tomás de (1836-1905)</author>
+        <title ref="wikidata:Q111096231">O Conde de S. Luís: Edição para o ELTeC</title>
+        <author ref="viaf:99963991 wikidata:Q10383136">Melo, Tomás de (1836-1905)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Júlio Reis</name>

--- a/level1/POR0035_MauFig_Exilado.xml
+++ b/level1/POR0035_MauFig_Exilado.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>O Exilado: Edição para o ELTeC</title>
-<author ref="viaf:99374069">Figueiredo, Maurícia C. de (1866-1923)</author>
+<title ref="wikidata:Q111096239">O Exilado: Edição para o ELTeC</title>
+<author ref="viaf:99374069 wikidata:Q111081934">Figueiredo, Maurícia C. de (1866-1923)</author>
        <respStmt>
            <resp>Criação do HTML original</resp>
 <name>Adeliana Silva</name>

--- a/level1/POR0036_JosAVie_Divorciada.xml
+++ b/level1/POR0036_JosAVie_Divorciada.xml
@@ -7,7 +7,7 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>A Divorciada: Edição para o ELTeC</title>
+<title ref="wikidata:Q19523497">A Divorciada: Edição para o ELTeC</title>
 <author ref="viaf:99891296">Vieira, José Augusto (1856-1890)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>

--- a/level1/POR0037_AntCamJ_Namorados.xml
+++ b/level1/POR0037_AntCamJ_Namorados.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>A Ala dos Namorados: Edição para o ELTeC</title>
-        <author ref="viaf:51255962">Campos Junior, António (1850-1917)</author>
+        <title ref="wikidata:Q111096170">A Ala dos Namorados: Edição para o ELTeC</title>
+        <author ref="viaf:51255962 wikidata:Q20045606">Campos Junior, António (1850-1917)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Luso-Livros</name>

--- a/level1/POR0038_AleHer_Bobo.xml
+++ b/level1/POR0038_AleHer_Bobo.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title> O Bobo : Edição para o ELTeC</title>
-<author ref="viaf:2464795">Herculano, Alexandre (1810-1877)</author>
+<title ref="wikidata:Q21515386"> O Bobo : Edição para o ELTeC</title>
+<author ref="viaf:2464795 wikidata:Q520688">Herculano, Alexandre (1810-1877)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Luso-livros</name>

--- a/level1/POR0039_InaPiz_Engeitado.xml
+++ b/level1/POR0039_InaPiz_Engeitado.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title> O Engeitado : Edição para o ELTeC</title>
+<title ref="wikidata:Q111096238"> O Engeitado : Edição para o ELTeC</title>
 <title level="s">Romance cristão</title>
-<author ref="viaf:87349884">Sarmento, Inácio Pizarro de Morais (1807-1870)</author>
+<author ref="viaf:87349884 wikidata:Q10303369">Sarmento, Inácio Pizarro de Morais (1807-1870)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Vanda Morgado</name>

--- a/level1/POR0040_AJCL_Tripeiros.xml
+++ b/level1/POR0040_AJCL_Tripeiros.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>Os tripeiros: Edição para o ELTeC</title>
+        <title ref="wikidata:Q111096270">Os tripeiros: Edição para o ELTeC</title>
 	<title level="s">Crónica do século XIV</title>
-        <author ref="viaf:99088245">Lousada, António José Coelho (1828-1859)</author>
+        <author ref="viaf:99088245 wikidata:Q111081936">Lousada, António José Coelho (1828-1859)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
            <name>Luso-Livros</name>

--- a/level1/POR0041_JoJoGra_Morte.xml
+++ b/level1/POR0041_JoJoGra_Morte.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>A morte vence: Edição para o ELTeC</title>
-<author ref="viaf:29789361">Grave, João José (1872-1934)</author>
+<title ref="wikidata:Q111096188">A morte vence: Edição para o ELTeC</title>
+<author ref="viaf:29789361 wikidata:Q5769261">Grave, João José (1872-1934)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Ricardo F. Diogo</name>

--- a/level1/POR0042_TeoBra_Viriato.xml
+++ b/level1/POR0042_TeoBra_Viriato.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Viriato: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096283">Viriato: Edição para o ELTeC</title>
 <title level="s">Narrativa epo-histórica</title>
-<author ref="viaf:54161310">Braga, Teófilo (1843-1924)</author>
+<author ref="viaf:54161310 wikidata:Q345926">Braga, Teófilo (1843-1924)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Pedro Saborano</name>

--- a/level1/POR0043_LuiMag_Soares.xml
+++ b/level1/POR0043_LuiMag_Soares.xml
@@ -7,8 +7,8 @@
         <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>O Brasileiro Soares: Edição para o ELTeC</title>
-<author ref="viaf:14814628">Magalhães, Luís de (1859-1935)</author>
+<title ref="wikidata:Q111096229">O Brasileiro Soares: Edição para o ELTeC</title>
+<author ref="viaf:14814628 wikidata:Q10321364">Magalhães, Luís de (1859-1935)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Adeliana Silva</name>

--- a/level1/POR0044_MAVC_Alice.xml
+++ b/level1/POR0044_MAVC_Alice.xml
@@ -7,7 +7,7 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Alice: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096201">Alice: Edição para o ELTeC</title>
 <author ref="viaf:43862761">Carvalho, Maria Amália Vaz de (1847-1921)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>

--- a/level1/POR0045_AntATVas_Castromino.xml
+++ b/level1/POR0045_AntATVas_Castromino.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>A ermida de Castromino: Edição para o ELTeC</title>
-<author ref="viaf:44308677">Vasconcelos, Antonio Augusto Teixeira de (1816-1878)</author>
+<title ref="wikidata:Q111096177">A ermida de Castromino: Edição para o ELTeC</title>
+<author ref="viaf:44308677 wikidata:Q16491165">Vasconcelos, Antonio Augusto Teixeira de (1816-1878)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Diana Santos</name>

--- a/level1/POR0046_FraGAmo_Selvagens.xml
+++ b/level1/POR0046_FraGAmo_Selvagens.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Os selvagens: Edição para o ELTeC</title>
-<author ref="viaf:13202408">Amorim, Francisco Gomes de (1827-1891)</author>
+<title ref="wikidata:Q111096269">Os selvagens: Edição para o ELTeC</title>
+<author ref="viaf:13202408 wikidata:Q178063">Amorim, Francisco Gomes de (1827-1891)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Diana Santos</name>

--- a/level1/POR0047_JosSMLea_Estouro.xml
+++ b/level1/POR0047_JosSMLea_Estouro.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Infaustas Aventuras de Mestre Marçal Estouro: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096217">Infaustas Aventuras de Mestre Marçal Estouro: Edição para o ELTeC</title>
 <title level="s">Vítima duma paixão</title>
-<author ref="viaf:8873105">Leal, José da Silva Mendes (1818-1886)</author>
+<author ref="viaf:8873105 wikidata:Q4993388">Leal, José da Silva Mendes (1818-1886)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Diana Santos</name>

--- a/level1/POR0048_BulPat_Palida.xml
+++ b/level1/POR0048_BulPat_Palida.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>A pálida estrela: Edição para o ELTeC</title>
-<author ref="viaf:50072721">Bulhão Pato, Raimundo António de (1828-1912)</author>
+<title ref="wikidata:Q111096189">A pálida estrela: Edição para o ELTeC</title>
+<author ref="viaf:50072721 wikidata:Q10357117">Bulhão Pato, Raimundo António de (1828-1912)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Diana Santos</name>

--- a/level1/POR0049_AntFBar_Cartuxo.xml
+++ b/level1/POR0049_AntFBar_Cartuxo.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>O último cartuxo da Scala Caeli de Évora: edição para o ELTeC: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096255">O último cartuxo da Scala Caeli de Évora: edição para o ELTeC: Edição para o ELTeC</title>
 <title level="s">Romance histórico (1808-1865)</title>
-<author ref="viaf:376726">Barata, António Francisco (1836-1910)</author>
+<author ref="viaf:376726 wikidata:Q84549907">Barata, António Francisco (1836-1910)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Vanda Morgado</name>

--- a/level1/POR0050_CarPAlm_Lisboa.xml
+++ b/level1/POR0050_CarPAlm_Lisboa.xml
@@ -7,7 +7,7 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>A conquista de Lisboa: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096174">A conquista de Lisboa: Edição para o ELTeC</title>
 <author>Almeida, Carlos Pinto de (1831-1899)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>

--- a/level1/POR0051_RauBra_Humus.xml
+++ b/level1/POR0051_RauBra_Humus.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Húmus: Edição para o ELTeC</title>
-<author ref="viaf:17219789">Brandão, Raul (1867-1930)</author>
+<title ref="wikidata:Q111096216">Húmus: Edição para o ELTeC</title>
+<author ref="viaf:17219789 wikidata:Q2035991">Brandão, Raul (1867-1930)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Luso-Livros</name>

--- a/level1/POR0052_RauBra_Farsa.xml
+++ b/level1/POR0052_RauBra_Farsa.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>A Farsa: Edição para o ELTeC</title>
-<author ref="viaf:17219789">Brandão, Raul (1867-1930)</author>
+<title ref="wikidata:Q111096178">A Farsa: Edição para o ELTeC</title>
+<author ref="viaf:17219789 wikidata:Q2035991">Brandão, Raul (1867-1930)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Luso-Livros</name>

--- a/level1/POR0053_AbeBot_Lavos.xml
+++ b/level1/POR0053_AbeBot_Lavos.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>O Barão de Lavos: Edição para o ELTeC</title>
-        <author ref="viaf:37048086">Botelho, Abel (1856-1917)</author>
+        <title ref="wikidata:Q8773586">O Barão de Lavos: Edição para o ELTeC</title>
+        <author ref="viaf:37048086 wikidata:Q318390">Botelho, Abel (1856-1917)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
         <name>Luso-Livros</name>

--- a/level1/POR0054_AbeBot_Amanha.xml
+++ b/level1/POR0054_AbeBot_Amanha.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>Amanhã: Edição para o ELTeC</title>
-        <author ref="viaf:37048086">Botelho, Abel (1856-1917)</author>
+        <title ref="wikidata:Q111096202">Amanhã: Edição para o ELTeC</title>
+        <author ref="viaf:37048086 wikidata:Q318390">Botelho, Abel (1856-1917)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
         <name>Luso-Livros</name>

--- a/level1/POR0055_AlbPim_Anel.xml
+++ b/level1/POR0055_AlbPim_Anel.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>O Annel Mysterioso: Edição para o ELTeC</title>
+        <title ref="wikidata:Q111096228">O Annel Mysterioso: Edição para o ELTeC</title>
         <title level="s">Scenas da Guerra Peninsular</title>
-        <author ref="viaf:64047987">Pimentel, Alberto (1849-1925)</author>
+        <author ref="viaf:64047987 wikidata:Q16487084">Pimentel, Alberto (1849-1925)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Pedro Saborano</name>

--- a/level1/POR0056_AliMod_Sandoval.xml
+++ b/level1/POR0056_AliMod_Sandoval.xml
@@ -7,8 +7,8 @@
   <teiHeader>
     <fileDesc>
       <titleStmt>
-        <title>O Dr. Luís Sandoval: Edição para o ELTeC</title>
-        <author ref="viaf:8943849">Moderno, Alice (1867-1946)</author>
+        <title ref="wikidata:Q111096237">O Dr. Luís Sandoval: Edição para o ELTeC</title>
+        <author ref="viaf:8943849 wikidata:Q16488592">Moderno, Alice (1867-1946)</author>
         <respStmt>
           <resp>Criação do HTML original</resp>
           <name>Diana Santos</name>

--- a/level1/POR0057_APLopMen_Doido.xml
+++ b/level1/POR0057_APLopMen_Doido.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>Memórias de um doido: Edição para o ELTeC</title>
+        <title ref="wikidata:Q111096223">Memórias de um doido: Edição para o ELTeC</title>
 <title level="s">romance contemporâneo</title>
-        <author ref="viaf:27059459">Mendonça, António Pedro Lopes de (1826-1865)</author>
+        <author ref="viaf:27059459 wikidata:Q16492186">Mendonça, António Pedro Lopes de (1826-1865)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Vanda Morgado</name>

--- a/level1/POR0058_AlbPim_Guerrilha.xml
+++ b/level1/POR0058_AlbPim_Guerrilha.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>A guerrilha de Frei Simão: Edição para o ELTeC</title>
+        <title ref="wikidata:Q111096180">A guerrilha de Frei Simão: Edição para o ELTeC</title>
 	<title level="s">Romance histórico</title>
-        <author ref="viaf:64047987">Pimentel, Alberto (1849-1925)</author>
+        <author ref="viaf:64047987 wikidata:Q16487084">Pimentel, Alberto (1849-1925)</author>
         <respStmt>
           <resp>Criação do HTML original</resp>
         <name>Rita Farinha</name>

--- a/level1/POR0059_AntFBar_Duelo.xml
+++ b/level1/POR0059_AntFBar_Duelo.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Um duelo nas sombras: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096277">Um duelo nas sombras: Edição para o ELTeC</title>
 <title level="s">ou D. Francisco Manuel de Melo (1630) </title>
-<author ref="viaf:376726">Barata, António Francisco (1836-1910)</author>
+<author ref="viaf:376726 wikidata:Q84549907">Barata, António Francisco (1836-1910)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Alina Baldé</name>

--- a/level1/POR0060_FiaAlm_Ruiva.xml
+++ b/level1/POR0060_FiaAlm_Ruiva.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>A ruiva: Edição para o ELTeC</title>
-        <author ref="viaf:27059459">Almeida, Fialho de (1857-1911)</author>
+        <title ref="wikidata:Q111096194">A ruiva: Edição para o ELTeC</title>
+        <author ref="viaf:27059459 wikidata:Q16492186">Almeida, Fialho de (1857-1911)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
        <name>Luso-livros</name>

--- a/level1/POR0061_LopSou_Lagrimas.xml
+++ b/level1/POR0061_LopSou_Lagrimas.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Herança de lágrimas: Edição para o ELTeC</title>
-<author ref="viaf:51767078">Souza, Lopo de [Ana Plácido] (1831-1895)</author>
+<title ref="wikidata:Q111096215">Herança de lágrimas: Edição para o ELTeC</title>
+<author ref="viaf:51767078 wikidata:Q9612570">Souza, Lopo de [Ana Plácido] (1831-1895)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Adeliana Silva</name>

--- a/level1/POR0062_AnaCO_Diario.xml
+++ b/level1/POR0062_AnaCO_Diario.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>Diário de uma criança: Edição para o ELTeC</title>
-        <author ref="viaf:68982250">Castro Osório, Ana de (1872-1935)</author>
+        <title ref="wikidata:Q111096207">Diário de uma criança: Edição para o ELTeC</title>
+        <author ref="viaf:68982250 wikidata:Q2817249">Castro Osório, Ana de (1872-1935)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>
         <name>Pedro Saborano</name>

--- a/level1/POR0063_RamOrt_Misterio.xml
+++ b/level1/POR0063_RamOrt_Misterio.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
      <titleStmt>
-        <title>O Mistério da Estrada de Sintra: Edição para o ELTeC</title>
-        <author ref="viaf:56623354">Ramalho Ortigão, José Duarte (1836-1915)</author>
+        <title ref="wikidata:Q10339438">O Mistério da Estrada de Sintra: Edição para o ELTeC</title>
+        <author ref="viaf:56623354 wikidata:Q2096754">Ramalho Ortigão, José Duarte (1836-1915)</author>
 	<author ref="viaf:88719234">Eça de Queirós, José Maria de (1845-1900)</author>
         <respStmt>
            <resp>Criação do HTML original</resp>

--- a/level1/POR0064_AntFBar_Manuelinho.xml
+++ b/level1/POR0064_AntFBar_Manuelinho.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>O Manuelinho de Évora: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096241">O Manuelinho de Évora: Edição para o ELTeC</title>
 <title level="s">romance histórico (1637) </title>
-<author ref="viaf:376726">Barata, António Francisco (1836-1910)</author>
+<author ref="viaf:376726 wikidata:Q84549907">Barata, António Francisco (1836-1910)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Inês Lucas</name>

--- a/level1/POR0065_MarONei_Marquesa.xml
+++ b/level1/POR0065_MarONei_Marquesa.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>A Marquesa de Vale Negro: Edição para o ELTeC</title>
-<author ref="viaf:100194833">O'Neil, Maria (1873-1932)</author>
+<title ref="wikidata:Q111096186">A Marquesa de Vale Negro: Edição para o ELTeC</title>
+<author ref="viaf:100194833 wikidata:Q6761467">O'Neil, Maria (1873-1932)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Adeliana Silva</name>

--- a/level1/POR0066_VirCA_Innocente.xml
+++ b/level1/POR0066_VirCA_Innocente.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Inocente: Edição para o ELTeC</title>
-<author ref="viaf:74000809">Castro e Almeida, Virgínia de (1874-1945)</author>
+<title ref="wikidata:Q111096218">Inocente: Edição para o ELTeC</title>
+<author ref="viaf:74000809 wikidata:Q19974549">Castro e Almeida, Virgínia de (1874-1945)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
        <name>André Rodrigues</name>

--- a/level1/POR0067_OliMar_Febo.xml
+++ b/level1/POR0067_OliMar_Febo.xml
@@ -7,8 +7,8 @@
         <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Febo Moniz: Edição para o ELTeC</title>
-<author ref="viaf:59092504">Oliveira Martins, Joaquim Pedro de (1845-1894)</author>
+<title ref="wikidata:Q111096212">Febo Moniz: Edição para o ELTeC</title>
+<author ref="viaf:59092504 wikidata:Q1399091">Oliveira Martins, Joaquim Pedro de (1845-1894)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Vanda Morgado</name>

--- a/level1/POR0068_ClaCam_Ele.xml
+++ b/level1/POR0068_ClaCam_Ele.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Ele : edição para o ELTeC</title>
-<author ref="viaf:1160148390823010830009">Campos, Claudia de (1859-1916)</author>
+<title ref="wikidata:Q111096209">Ele : edição para o ELTeC</title>
+<author ref="viaf:1160148390823010830009 wikidata:Q17280314">Campos, Claudia de (1859-1916)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Adeliana Silva</name>

--- a/level1/POR0069_MPerSou_Henriqueta.xml
+++ b/level1/POR0069_MPerSou_Henriqueta.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Henriqueta: Edição para o ELTeC</title>
-<author ref="viaf:99377085">Sousa, Maria Peregrina de (1809-1886)</author>
+<title ref="wikidata:Q111096214">Henriqueta: Edição para o ELTeC</title>
+<author ref="viaf:99377085 wikidata:Q111081944">Sousa, Maria Peregrina de (1809-1886)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Adeliana Silva</name>

--- a/level1/POR0070_MatBet_Aljubarrota.xml
+++ b/level1/POR0070_MatBet_Aljubarrota.xml
@@ -7,7 +7,7 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>O soldado de Aljubarrota: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096253">O soldado de Aljubarrota: Edição para o ELTeC</title>
 <author ref="viaf:99468828">Bettencourt, Matilde Isabel de Santana e Vasconcelos Moniz (1805-1888)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>

--- a/level1/POR0071_OliMas_Arrabido.xml
+++ b/level1/POR0071_OliMas_Arrabido.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>O frade arrábido: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096240">O frade arrábido: Edição para o ELTeC</title>
 <title level="s">Romance historico do século XVIII</title>
-<author ref="viaf:100130648">Oliveira Mascarenhas, Joaquim Augusto de (1847-1918)</author>
+<author ref="viaf:100130648 wikidata:Q109856910">Oliveira Mascarenhas, Joaquim Augusto de (1847-1918)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Madalena Rato</name>

--- a/level1/POR0072_LobAvi_Caramurus.xml
+++ b/level1/POR0072_LobAvi_Caramurus.xml
@@ -7,7 +7,7 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Os Caramurús: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096259">Os Caramurús: Edição para o ELTeC</title>
 <title level="s"> romance histórico da descoberta e independência do Brasil</title>
 <author>Lobo de Ávila, Artur (1855-1945)</author>
 <respStmt>

--- a/level1/POR0073_MatMor_Tempestades.xml
+++ b/level1/POR0073_MatMor_Tempestades.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Tempestades do coração: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096274">Tempestades do coração: Edição para o ELTeC</title>
 <title level="s">Romance contemporâneo </title>
-<author ref="viaf:100139864">Moreira, João Baptista de Matos (1845-1899)</author>
+<author ref="viaf:100139864 wikidata:Q111081938">Moreira, João Baptista de Matos (1845-1899)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Madalena Rato</name>

--- a/level1/POR0074_CarMDia_Ervas.xml
+++ b/level1/POR0074_CarMDia_Ervas.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Filho das ervas: Edição para o ELTeC</title>
-<author ref="viaf:29528314">Dias, Carlos Malheiro (1875-1941)</author>
+<title ref="wikidata:Q111096213">Filho das ervas: Edição para o ELTeC</title>
+<author ref="viaf:29528314 wikidata:Q9697193">Dias, Carlos Malheiro (1875-1941)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Diana Santos</name>

--- a/level1/POR0075_ForCPin_Agitador.xml
+++ b/level1/POR0075_ForCPin_Agitador.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>O agitador: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096226">O agitador: Edição para o ELTeC</title>
 <title level="s">Romance </title>
-<author ref="viaf:99791256">Pinto, Fortunato Correia (18??-19??)</author>
+<author ref="viaf:99791256 wikidata:Q111081940">Pinto, Fortunato Correia (18??-19??)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Alina Baldé</name>

--- a/level1/POR0076_FraFBen_Franceses.xml
+++ b/level1/POR0076_FraFBen_Franceses.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>No tempo dos francezes: Edição para o ELTeC</title>
-<author ref="viaf:99791256">Benevides, Francisco da Fonseca (1836-1911)</author>
+<title ref="wikidata:Q111096224">No tempo dos francezes: Edição para o ELTeC</title>
+<author ref="viaf:99791256 wikidata:Q111081940">Benevides, Francisco da Fonseca (1836-1911)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Alina Balté</name>

--- a/level1/POR0077_JosJRBas_Deserto.xml
+++ b/level1/POR0077_JosJRBas_Deserto.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>O médico do deserto: Edição para o ELTeC</title>
-<author ref="viaf:89396752">Bastos, José Joaquim Rodrigues de (1777-1862)</author>
+<title ref="wikidata:Q111096243">O médico do deserto: Edição para o ELTeC</title>
+<author ref="viaf:89396752 wikidata:Q21483097">Bastos, José Joaquim Rodrigues de (1777-1862)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Vanda Morgado</name>

--- a/level1/POR0078_EduNor_Agonizar.xml
+++ b/level1/POR0078_EduNor_Agonizar.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>O agonizar de uma dinastia: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096227">O agonizar de uma dinastia: Edição para o ELTeC</title>
 <title level="s">O calvário de uma mãe</title>
-<author ref="viaf:89396752">Noronha, Eduardo de (1859-1948)</author>
+<author ref="viaf:89396752 wikidata:Q21483097">Noronha, Eduardo de (1859-1948)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Alina Balté</name>

--- a/level1/POR0079_JulLPin_Margarida.xml
+++ b/level1/POR0079_JulLPin_Margarida.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Margarida: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096220">Margarida: Edição para o ELTeC</title>
 <title level="s">Scenas da vida contemporanea </title>
-<author ref="viaf:302032361">Pinto, Júlio Lourenço (1842-1907)</author>
+<author ref="viaf:302032361 wikidata:Q10313447">Pinto, Júlio Lourenço (1842-1907)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Vanda Morgado</name>

--- a/level1/POR0080_JoaCam_CastelMelhor.xml
+++ b/level1/POR0080_JoaCam_CastelMelhor.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>O Conde de Castel Melhor: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096230">O Conde de Castel Melhor: Edição para o ELTeC</title>
 <title level="s">romance histórico </title>
-<author ref="viaf:12317246">Câmara, João Maria Evangelista Gonçalves Zarco da (1852-1908)</author>
+<author ref="viaf:12317246 wikidata:Q10311573">Câmara, João Maria Evangelista Gonçalves Zarco da (1852-1908)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Inês Lucas</name>

--- a/level1/POR0081_AMCunSa_Parte.xml
+++ b/level1/POR0081_AMCunSa_Parte.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Da parte d'el-rei: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096206">Da parte d'el-rei: Edição para o ELTeC</title>
 <title level="s">Romance histórico do século XIV</title>
-<author ref="viaf:14405749">Sá, António Manuel da Cunha e (1854-1909)</author>
+<author ref="viaf:14405749 wikidata:Q55838239">Sá, António Manuel da Cunha e (1854-1909)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Inês Lucas</name>

--- a/level1/POR0082_JulCMac_Lisboa.xml
+++ b/level1/POR0082_JulCMac_Lisboa.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>A vida em Lisboa: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096199">A vida em Lisboa: Edição para o ELTeC</title>
 <title level="s">romance contemporâneo</title>
-<author ref="viaf:61792274">Machado, Júlio César (1835-1890) </author>
+<author ref="viaf:61792274 wikidata:Q10313403">Machado, Júlio César (1835-1890) </author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Inês Lucas</name>

--- a/level1/POR0083_AliPes_Prejuizo.xml
+++ b/level1/POR0083_AliPes_Prejuizo.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>A vida por um prejuízo: Edição para o ELTeC</title>
-<author ref="viaf:23763399">Pestana, Alice (1860-1929) </author>
+<title ref="wikidata:Q111096200">A vida por um prejuízo: Edição para o ELTeC</title>
+<author ref="viaf:23763399 wikidata:Q16911690">Pestana, Alice (1860-1929) </author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Diana Santos</name>

--- a/level1/POR0084_FraLGom_Bramanes.xml
+++ b/level1/POR0084_FraLGom_Bramanes.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Os Brâmanes: Edição para o ELTeC</title>
-<author ref="viaf:21089001">Gomes, Francisco Luís (1829-1869) </author>
+<title ref="wikidata:Q111096256">Os Brâmanes: Edição para o ELTeC</title>
+<author ref="viaf:21089001 wikidata:Q5483610">Gomes, Francisco Luís (1829-1869) </author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Vanda Morgado</name>

--- a/level1/POR0085_AugSar_Providencia.xml
+++ b/level1/POR0085_AugSar_Providencia.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Providência: Edição para o ELTeC</title>
-<author ref="viaf:99738093">Sarmento, Augusto (1835-?) </author>
+<title ref="wikidata:Q111096272">Providência: Edição para o ELTeC</title>
+<author ref="viaf:99738093 wikidata:Q111081943">Sarmento, Augusto (1835-?) </author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Inês Lucas</name>

--- a/level1/POR0086_MBenPin_Marina.xml
+++ b/level1/POR0086_MBenPin_Marina.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Marina: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096221">Marina: Edição para o ELTeC</title>
 <title level="s">Romance passional </title>
-<author ref="viaf:99357484">Pinho, Maria Benedicta Mousinho de Albuquerque (1865-1939)</author>
+<author ref="viaf:99357484 wikidata:Q61000747">Pinho, Maria Benedicta Mousinho de Albuquerque (1865-1939)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Madalena Rato</name>

--- a/level1/POR0087_MarMes_Impostores.xml
+++ b/level1/POR0087_MarMes_Impostores.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Os quatro reis impostores: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096268">Os quatro reis impostores: Edição para o ELTeC</title>
 <title level="s">Romance da história </title>
-<author ref="viaf:62652518">Mesquita, Marcelino (1856-1919)</author>
+<author ref="viaf:62652518 wikidata:Q10325012">Mesquita, Marcelino (1856-1919)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Alina Baldé</name>

--- a/level1/POR0088_PerVar_Miseraveis.xml
+++ b/level1/POR0088_PerVar_Miseraveis.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Os miseráveis da aristocracia: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096266">Os miseráveis da aristocracia: Edição para o ELTeC</title>
 <title level="s">Romance social contemporâneo </title>
-<author ref="viaf:63838316">Varela, A.J. Pereira (?-1878)</author>
+<author ref="viaf:63838316 wikidata:Q111081945">Varela, A.J. Pereira (?-1878)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Inês Lucas</name>

--- a/level1/POR0089_AlvCar_Canibais.xml
+++ b/level1/POR0089_AlvCar_Canibais.xml
@@ -7,7 +7,7 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Os canibais: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096258">Os canibais: Edição para o ELTeC</title>
 <author ref="viaf:12340043">Carvalhal, Álvaro do (1844-1868)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>

--- a/level1/POR0090_CanFig_Tres.xml
+++ b/level1/POR0090_CanFig_Tres.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Lisboa no Ano Três Mil: Edição para o ELTeC</title>
-<author ref="viaf:7482362">Figueiredo, Cândido de (1846-1925)</author>
+<title ref="wikidata:Q111096219">Lisboa no Ano Três Mil: Edição para o ELTeC</title>
+<author ref="viaf:7482362 wikidata:Q10263005">Figueiredo, Cândido de (1846-1925)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Ricardo Lourenço</name> 

--- a/level1/POR0091_ArnGam_Dinheiro.xml
+++ b/level1/POR0091_ArnGam_Dinheiro.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>El-rei dinheiro: Edição para o ELTeC</title>
-<author ref="viaf:34585149">Gama, Arnaldo (1828-1869)</author>
+<title ref="wikidata:Q111096208">El-rei dinheiro: Edição para o ELTeC</title>
+<author ref="viaf:34585149 wikidata:Q16493906">Gama, Arnaldo (1828-1869)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Vanda Morgado</name>

--- a/level1/POR0092_UrbLou_Quintino.xml
+++ b/level1/POR0092_UrbLou_Quintino.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>A infâmia de Frei Quintino: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096183">A infâmia de Frei Quintino: Edição para o ELTeC</title>
 <title level="s">Romance duma família </title>
-<author ref="viaf:78355897">Loureiro, Urbano (1845-1880)</author>
+<author ref="viaf:78355897 wikidata:Q23771077">Loureiro, Urbano (1845-1880)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Vanda Morgado</name>

--- a/level1/POR0093_AnMRSa_Mathilde.xml
+++ b/level1/POR0093_AnMRSa_Mathilde.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Mathilde: Edição para o ELTeC</title>
-<author ref="viaf:98850225">Sá, Ana Maria Ribeiro de (?-?)</author>
+<title ref="wikidata:Q111096222">Mathilde: Edição para o ELTeC</title>
+<author ref="viaf:98850225 wikidata:Q111081941">Sá, Ana Maria Ribeiro de (?-?)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Alina Baldé</name>

--- a/level1/POR0094_BerPPin_Arzilla.xml
+++ b/level1/POR0094_BerPPin_Arzilla.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Arzila: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096205">Arzila: Edição para o ELTeC</title>
 <title level="s">Romance do século XV </title>
-<author ref="viaf:98582867">Pinheiro, Bernardino Pereira (1837-1896)</author>
+<author ref="viaf:98582867 wikidata:Q16497940">Pinheiro, Bernardino Pereira (1837-1896)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Alina Baldé</name>

--- a/level1/POR0095_AlfMes_Rua.xml
+++ b/level1/POR0095_AlfMes_Rua.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>A rua do oiro: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096193">A rua do oiro: Edição para o ELTeC</title>
 <title level="s">Romance lisboeta </title>
-<author ref="viaf:75465963">Mesquita, Alfredo de (1871-1931)</author>
+<author ref="viaf:75465963 wikidata:Q9603240">Mesquita, Alfredo de (1871-1931)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Inês Lucas</name>

--- a/level1/POR0096_ManCPCou_Elvenda.xml
+++ b/level1/POR0096_ManCPCou_Elvenda.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Elvenda, ou Conquista de Coimbra por Fernando Magno: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096210">Elvenda, ou Conquista de Coimbra por Fernando Magno: Edição para o ELTeC</title>
 <title level="s">Romance histórico e moral elaborado sobre factos do século XI</title>
-<author ref="viaf:100053391">Coutinho, Manuel da Cruz Pereira (1808-1880)</author>
+<author ref="viaf:100053391 wikidata:Q111081933">Coutinho, Manuel da Cruz Pereira (1808-1880)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Madalena Rato</name>

--- a/level1/POR0097_FraBLob_Gil.xml
+++ b/level1/POR0097_FraBLob_Gil.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>O Tio João Gil: Edição para o ELTeC</title>
+<title ref="wikidata:Q111096254">O Tio João Gil: Edição para o ELTeC</title>
 <title level="s">Crónica d'Aldeia</title>
-<author ref="viaf:99349874">Lobo, Francisco Barros (? - ?)</author>
+<author ref="viaf:99349874 wikidata:Q111081935">Lobo, Francisco Barros (? - ?)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Madalena Rato</name>

--- a/level1/POR0098_AugLou_Bruxa.xml
+++ b/level1/POR0098_AugLou_Bruxa.xml
@@ -7,9 +7,9 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>A bruxa : Edição para o ELTeC</title>
+<title ref="wikidata:Q111096171">A bruxa : Edição para o ELTeC</title>
 <title level="s">Cenas açorianas </title>
-<author ref="viaf:201044294">Loureiro, Augusto (1840-?)</author>
+<author ref="viaf:201044294 wikidata:Q19607717">Loureiro, Augusto (1840-?)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Vanda Morgado</name>

--- a/level1/POR0099_AnaCO_Ambicoes.xml
+++ b/level1/POR0099_AnaCO_Ambicoes.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>Ambições : Edição para o ELTeC</title>
-<author ref="viaf:68982250">Castro Osório, Ana de (1872-1935)</author>
+<title ref="wikidata:Q111096203">Ambições : Edição para o ELTeC</title>
+<author ref="viaf:68982250 wikidata:Q2817249">Castro Osório, Ana de (1872-1935)</author>
 <respStmt>
   <resp>Criação do HTML original</resp>
   <name>Vanda Morgado</name>

--- a/level1/POR0100_LucCor_Duquesa.xml
+++ b/level1/POR0100_LucCor_Duquesa.xml
@@ -7,8 +7,8 @@
 <teiHeader>
 <fileDesc>
 <titleStmt>
-<title>A senhora duquesa: Edição para o ELTeC</title>
-<author ref="viaf:4959274">Cordeiro, Luciano (1844-1900)</author>
+<title ref="wikidata:Q111096196">A senhora duquesa: Edição para o ELTeC</title>
+<author ref="viaf:4959274 wikidata:Q971935">Cordeiro, Luciano (1844-1900)</author>
 <respStmt>
 <resp>Criação do HTML original</resp>
 <name>Madalena Rato</name>


### PR DESCRIPTION
Added wikidata:QXXXXX identifiers to the ref attribute of <title> and <author> elements in <titleStmt> for level1 texts.  Author IDs added: 90 | Work IDs added: 100
Wikidata IDs obtained via SPARQL (author: VIAF lookup; work: Portuguese `@pt` label search).